### PR TITLE
fix encoding of the JSON data object

### DIFF
--- a/src/game.haml
+++ b/src/game.haml
@@ -7,7 +7,7 @@
     != javascript('libs/underscore-min.js')
     != javascript('libs/jquery-3.1.1.min.js')
     :javascript
-      window.Game = { config: JSON.parse('#{ JSON.generate(CONFIG) }') };
+      window.Game = { config: #{ JSON.dump(CONFIG) } };
     != javascript('game.js')
     != javascript('handlers.js')
     != javascript('main.js')


### PR DESCRIPTION
Instead of using JSON.parse and putting the JSON inside of a string, we can just directly insert the JSON into the generated JavaScript.
Note JSON can contain single quotes and is therefore harder to securely escape if inserted as a string.

Note: It is not a problem to directly insert the JSON into JavaScript as JSON is a strict subset of the JavaScript language.
I acidently swapped `JSON.generate` to `JSON.dump`, this should not matter as dump just calls generate on the object. Can swap this back if wanted.